### PR TITLE
Refine our identification of `lazy` function calls

### DIFF
--- a/tests/NoEqualityBreakingLazyArgsTest.elm
+++ b/tests/NoEqualityBreakingLazyArgsTest.elm
@@ -5,6 +5,91 @@ import Review.Test
 import Test exposing (Test, describe, test)
 
 
+importTests : Test
+importTests =
+    let
+        badLambda =
+            "(\\s -> text s)"
+
+        hasError source =
+            ("module A exposing (..)\n" ++ source ++ " " ++ badLambda)
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "This must be a top level function in order to be properly optimized by lazy"
+                        , details = [ "Do this" ]
+                        , under = badLambda
+                        }
+                    ]
+    in
+    describe "Import Tests"
+        [ test "should identify the lazy function when module imported unaliased (Html.Lazy)" <|
+            \() ->
+                """
+import Html.Lazy
+
+x = Html.Lazy.lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported unaliased (Html.Styled.Lazy)" <|
+            \() ->
+                """
+import Html.Styled.Lazy
+
+x = Html.Styled.Lazy.lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported aliased (Html.Lazy)" <|
+            \() ->
+                """
+import Html.Lazy as Lazy
+
+x = Lazy.lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported aliased (Html.Styled.Lazy)" <|
+            \() ->
+                """
+import Html.Styled.Lazy as Lazy
+
+x = Lazy.lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported explicitly (Html.Lazy)" <|
+            \() ->
+                """
+import Html.Lazy exposing (lazy)
+
+x = lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported explicitly (Html.Styled.Lazy)" <|
+            \() ->
+                """
+import Html.Styled.Lazy exposing (lazy)
+
+x = lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported exposing all (Html.Lazy)" <|
+            \() ->
+                """
+import Html.Lazy exposing (..)
+
+x = lazy
+"""
+                    |> hasError
+        , test "should identify the lazy function when module imported exposing all (Html.Styled.Lazy)" <|
+            \() ->
+                """
+import Html.Styled.Lazy exposing (..)
+
+x = lazy
+"""
+                    |> hasError
+        ]
+
+
 firstArgumentTests : Test
 firstArgumentTests =
     let
@@ -86,5 +171,6 @@ x = lazy (y "Sample ") "Text"
 all : Test
 all =
     describe "NoEqualityBreakingLazyArgs"
-        [ firstArgumentTests
+        [ importTests
+        , firstArgumentTests
         ]


### PR DESCRIPTION
`elm-review` offers us the [`moduleNameFor`](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/Review-ModuleNameLookupTable#moduleNameFor) function which *almost* works to identify which module a function originates from.  Sadly, it does not handle the case when an `import` exposes all contents of a module (e.g. `import Html.lazy exposing (..)`.  This is typically considered bad Elm practice, but we should handle it anyways. 

The basic approach to solving this is to keep track of all modules that were imported exposing all using `withImportVisitor`.  Since we know exactly which functions in the `Html.Lazy` and `Html.Styled.Lazy` modules we are looking for ( `lazy`/`lazy2`/.../`lazy8` ) we can then tie the knot whenever we encounter an unqualified `lazyX` function while having one of our modules imported exposing all. 